### PR TITLE
Diffbot knowledge graph url is updated to new url from deprecated url

### DIFF
--- a/src/diffbot.js
+++ b/src/diffbot.js
@@ -431,7 +431,7 @@ class Diffbot {
     else if (options.jsonmode && options.jsonmode != 'extended')
       throw new Error('invalid jsonmode');
 
-    let diffbot_url = `https://kg.diffbot.com/kg/dql_endpoint?token=${this.token}&query=${encodeURIComponent(options.query)}`;
+      let diffbot_url = `https://kg.diffbot.com/kg/v3/dql?token=${this.token}&query=${encodeURIComponent(options.query)}`;
 
     if (options.type)
       diffbot_url += `&type=${options.type}`;

--- a/src/diffbot.js
+++ b/src/diffbot.js
@@ -431,7 +431,7 @@ class Diffbot {
     else if (options.jsonmode && options.jsonmode != 'extended')
       throw new Error('invalid jsonmode');
 
-      let diffbot_url = `https://kg.diffbot.com/kg/v3/dql?token=${this.token}&query=${encodeURIComponent(options.query)}`;
+    let diffbot_url = `https://kg.diffbot.com/kg/v3/dql?token=${this.token}&query=${encodeURIComponent(options.query)}`;
 
     if (options.type)
       diffbot_url += `&type=${options.type}`;

--- a/test/knowledge-graph.test.js
+++ b/test/knowledge-graph.test.js
@@ -14,7 +14,7 @@ describe('Knowledge Graph Tests', function() {
 
     let request = await diffbot.knowledgeGraph({ query, type, size, from, jsonmode, nonCanonicalFacts, noDedupArticles });
 
-    expect(request.url).to.equal(`https://kg.diffbot.com/kg/dql_endpoint?token=${diffbot.token}&query=${encodeURIComponent(query)}&type=${type}&size=${size}&from=${from}&jsonmode=${jsonmode}&nonCanonicalFacts=${+nonCanonicalFacts}&noDedupArticles=${+noDedupArticles}`);
+    expect(request.url).to.equal(`https://kg.diffbot.com/kg/v3/dql?token=${diffbot.token}&query=${encodeURIComponent(query)}&type=${type}&size=${size}&from=${from}&jsonmode=${jsonmode}&nonCanonicalFacts=${+nonCanonicalFacts}&noDedupArticles=${+noDedupArticles}`);
     expect(request.method).to.equal('GET');
     expect(request.body).to.be.undefined;
     expect(request.headers).to.be.an('object').that.is.empty;


### PR DESCRIPTION
Hi, diffbot knowledge graph url is deprecated and not working now, you should use new one.